### PR TITLE
Include native Rust code in Hex release

### DIFF
--- a/docs/github_token_guide.md
+++ b/docs/github_token_guide.md
@@ -1,6 +1,6 @@
 # Setting Up a GitHub Personal Access Token for Exstatic
 
-This guide walks you through creating a **GitHub Personal Access Token (PAT)** to allow Exstatic to authenticate and fetch precompiled NIFs from a private repository.
+This guide walks you through creating a **GitHub Personal Access Token (PAT)** to allow Exstatic to authenticate and fetch precompiled NIFs from a private repository. If/when Exstatic becomes a public repo this will not be necessary.
 
 ## 1️⃣  Generate a New Token
 

--- a/lib/exstatic/release_helper.ex
+++ b/lib/exstatic/release_helper.ex
@@ -1,6 +1,8 @@
 defmodule Exstatic.ReleaseHelper do
   @moduledoc """
-  A helper module for fetching precompiled assets from a private GitHub release.
+  A helper module for fetching precompiled assets from a private GitHub release. 
+
+  If/when Exstatic becomes a public repo this will not be necessary.
 
   This module is designed to work with `RustlerPrecompiled`, allowing it to dynamically
   fetch the correct precompiled NIF binaries from a GitHub release using the GitHub API.

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,8 @@ defmodule Exstatic.MixProject do
     [
       name: "exstatic",
       organization: "zappi",
-      files: ~w(lib mix.exs README.md checksum-*.exs),
+      files:
+        ~w(lib native/exstatic/src native/exstatic/Cargo.toml mix.exs README.md checksum-*.exs),
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url}
     ]


### PR DESCRIPTION
# Summary
Includes the native source code in the hex release if folks want to build the rust backend locally (can be done by setting `EXSTATIC_BUILD=true`).
