### PR TITLE
Build for Ubuntu 20.04 instead of 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           - { target: x86_64-apple-darwin, os: macos-13, platform: "MacOS (x86_64)" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, platform: "Linux (x86_64, default)" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, platform: "Linux (x86_64, legacy)", variant: "legacy_cpu" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true, platform: "Linux (musl, static)" }
+            #- { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true, platform: "Linux (musl, static)" }
 
     env:
       EXSTATIC_BUILD: true  # Ensure RustlerPrecompiled forces a build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,11 @@ jobs:
         nif: ["2.16"]
         job:
           - { target: aarch64-apple-darwin, os: macos-13, platform: "macOS (ARM64)" }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-22.04, use-cross: true, platform: "Linux (ARM64)" }
-          - { target: x86_64-apple-darwin, os: macos-13, platform: "macOS (x86_64)" }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04, platform: "Linux (x86_64)" }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true, platform: "Linux (ARM64)" }
+          - { target: x86_64-apple-darwin, os: macos-13, platform: "MacOS (x86_64)" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, platform: "Linux (x86_64, default)" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, platform: "Linux (x86_64, legacy)", variant: "legacy_cpu" }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true, platform: "Linux (musl, static)" }
 
     env:
       EXSTATIC_BUILD: true  # Ensure RustlerPrecompiled forces a build
@@ -71,6 +73,7 @@ jobs:
           target: ${{ matrix.job.target }}
           nif-version: ${{ matrix.nif }}
           use-cross: ${{ matrix.job.use-cross }}
+          variant: ${{ matrix.job.variant }}
           project-dir: "native/exstatic"
 
       - name: Upload compiled NIF artifact
@@ -85,3 +88,4 @@ jobs:
           files: |
             ${{ steps.build-crate.outputs.file-path }}
         if: startsWith(github.ref, 'refs/tags/')
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
           - { target: x86_64-apple-darwin, os: macos-13, platform: "MacOS (x86_64)" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, platform: "Linux (x86_64, default)" }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, platform: "Linux (x86_64, legacy)", variant: "legacy_cpu" }
-            #- { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true, platform: "Linux (musl, static)" }
 
     env:
       EXSTATIC_BUILD: true  # Ensure RustlerPrecompiled forces a build
@@ -88,4 +87,3 @@ jobs:
           files: |
             ${{ steps.build-crate.outputs.file-path }}
         if: startsWith(github.ref, 'refs/tags/')
-

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Exstatic.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @repo "Intellection/exstatic"
   @source_url "https://github.com/#{@repo}"
 

--- a/native/exstatic/Cargo.toml
+++ b/native/exstatic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exstatic"
-version = "0.1.0"
+version = "0.2.0"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
### Issue
We're precompiling for ubuntu-22.04 which comes with glibc 2.35. Our CI and Prod builds use Debian for all of our Elixir apps and the Debian version they use comes with glibc 2.33.
```shell
12:07:53.333 [warning] The on_load function for module Elixir.Exstatic.Native returned:
{:error,
 {:load_failed,
  ~c"Failed to load NIF library: '/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /root/project/_build/test/lib/exstatic/priv/native/libexstatic-v0.2.0-nif-2.16-x86_64-unknown-linux-gnu.so)'"}}
```

Also I added a couple of extra build targets.

### This PR
Switches Linux builds to ubuntu-20.04 which comes with glibc 2.31. [Github Actions doesn't come with Debian runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for--private-repositories) 🫠, so this is the next best thing (if this works). 

glibc 2.33 should be compatible with 2.31.

